### PR TITLE
Issues resolved: GH-252

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,9 +265,12 @@
 
 
 	<div class="box"> 
-		<h2>Tooltip</h2> 
-		<img class="YOUR_SELECTOR_Tooltip" title="Good seller" src="http://img.mlstatic.com/org-img/rp2/termometro_vip_2/11.gif"> 
-
+		<h2>Tooltip</h2>
+		<img class="YOUR_SELECTOR_Tooltip" alt="Good seller - alt" src="http://img.mlstatic.com/org-img/rp2/termometro_vip_2/11.gif">
+		<br>
+		<img class="YOUR_SELECTOR_Tooltip" title="Good seller - title" src="http://img.mlstatic.com/org-img/rp2/termometro_vip_2/11.gif">
+		<br>
+		<img class="YOUR_SELECTOR_Tooltip" title="Good seller - title" alt="Good seller - alt" src="http://img.mlstatic.com/org-img/rp2/termometro_vip_2/11.gif">
 	</div> 
 
 

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -23,7 +23,7 @@ ch.tooltip = function(conf) {
 	
 	conf = ch.clon(conf);
 	conf.cone = true;
-	conf.content = that.element.title || that.element.alt;	
+	conf.content = that.element.title || that.element.alt;
 	conf.position = {};
 	conf.position.context = $(that.element);
 	conf.position.offset = conf.offset || "0 10";
@@ -42,7 +42,14 @@ ch.tooltip = function(conf) {
 /**
  *  Private Members
  */
-
+	/**
+     * The attribute that will provide the content. It can be "title" or "alt" attributes.
+     * @private
+     * @name contentReference
+     * @type {string}
+     * @memberOf ch.Tooltip
+     */ 
+	var contentReference = (that.element.title) ? "title" : "alt";
     
 /**
  *  Protected Members
@@ -50,14 +57,14 @@ ch.tooltip = function(conf) {
     that.$trigger = that.$element;
 
     that.show = function(event) {
-        that.$trigger.attr('title', ''); // IE8 remembers the attribute even when is removed, so ... empty the attribute to fix the bug.
+        that.element[contentReference] = ""; // IE8 remembers the attribute even when is removed, so ... empty the attribute to fix the bug.
 		that.parent.show(event);
 		
 		return that;
 	};
 	
     that.hide = function(event) {
-		that.$trigger.attr('title', conf.content);
+		that.element[contentReference] = conf.content;
 		that.parent.hide(event);
 		
 		return that;


### PR DESCRIPTION
GH-252 Tooltip: On show() and hide() methods, only title attribute is removed and rewritten.
