### PR TITLE
Validation: Posiciona el scroll cerca del primer mensaje de error

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -1,4 +1,3 @@
-
 /**
 * Forms is a Controller of DOM's HTMLFormElement.
 * @name Form
@@ -124,6 +123,14 @@ ch.form = function(conf) {
 			} else {
 				childrenError[0].element.focus();
 			}
+			// Sets scroll near Helper's position
+			var vPos = 0;
+			var oElement = childrenError[0].helper.element;
+			while (oElement != null) {
+				vPos += oElement.offsetTop;
+				oElement = oElement.offsetParent;
+			}
+			window.scrollTo(0, vPos);
 		} else {
 			status = true;
 		}


### PR DESCRIPTION
Permite que el usuario lea el mensaje que indica el error aunque la validación no esté asociada a un INPUT.

Incluso, si el mensaje se elijiera posicionar lejos del INPUT que se valida deja el mensaje visible.
