### PR TITLE
Autocomplete improvements

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,6 +217,8 @@ gulp.task('browser-sync', ['build'], function () {
         }
     });
 
+    gulp.watch(['src/shared/**/*.js', 'src/ui/**/*.js'], ['concatJS:ui']);
+    gulp.watch(['src/shared/**/*.js', 'src/mobile/**/*.js'], ['concatJS:mobile']);
     gulp.watch('dist/**/*.js').on('change', reload);
     gulp.watch('src/views/*.html').on('change', reload);
     gulp.watch('src/**/styles/**/*.scss', ['sass']);

--- a/src/mobile/styles/_autocomplete.scss
+++ b/src/mobile/styles/_autocomplete.scss
@@ -3,6 +3,10 @@
 
 .ch-autocomplete {
     padding: $autocomplete-padding;
+
+    &-wrapper {
+        display: block;
+    }
 }
 
 .ch-autocomplete-item {

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -220,7 +220,7 @@
         tiny.on(this.container, highlightEvent, this._highlightSuggestion);
 
 
-        tiny.on(this.container, ch.onpointerdown, function itemEvents(event) {
+        tiny.on(this.container, ch.onpointertap, function itemEvents(event) {
             var target = event.target || event.srcElement;
 
             // completes the value, it is a shortcut to avoid write the complete word

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -47,6 +47,8 @@
      * @param {Number} [options.offsetX] The offsetX option specifies a distance to displace the target horitontally.
      * @param {Number} [options.offsetY] The offsetY option specifies a distance to displace the target vertically.
      * @param {String} [options.positioned] The positioned option specifies the type of positioning used. You must use: "absolute" or "fixed". Default: "absolute".
+     * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
+     *
      * @returns {autocomplete}
      * @example
      * // Create a new AutoComplete.
@@ -99,7 +101,6 @@
         window.setTimeout(function () { that.emit('ready'); }, 50);
 
         return this;
-
     }
 
     // Inheritance
@@ -137,7 +138,8 @@
         'html': false,
         '_hiddenby': 'none',
         'keystrokesTime': 150,
-        '_itemTemplate': '<li class="{{itemClass}}"{{suggestedData}}>{{term}}<i class="ch-icon-arrow-up" data-js="ch-autocomplete-complete-query"></i></li>'
+        '_itemTemplate': '<li class="{{itemClass}}"{{suggestedData}}>{{term}}<i class="ch-icon-arrow-up" data-js="ch-autocomplete-complete-query"></i></li>',
+        'wrapper': false
     };
 
     /**
@@ -176,8 +178,10 @@
             'addClass': this._options.addClass,
             'hiddenby': this._options._hiddenby,
             'width': this._el.getBoundingClientRect().width + 'px',
-            'fx': this._options.fx
+            'fx': this._options.fx,
+            'wrapper': this._options.wrapper
         });
+
         /**
          * The autocomplete container.
          * @type {HTMLDivElement}

--- a/src/shared/scripts/Layer.js
+++ b/src/shared/scripts/Layer.js
@@ -26,6 +26,8 @@
      * @param {Boolean} [options.async] Force to sent request asynchronously. Default: true.
      * @param {(String | HTMLElement)} [options.waiting] Temporary content to use while the ajax request is loading. Default: '&lt;div class="ch-loading ch-loading-centered"&gt;&lt;/div&gt;'.
      * @param {( String | HTMLElement)} [options.content] The content to be shown into the Layer container.
+     * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
+     *
      * @returns {layer} Returns a new instance of Layer.
      * @example
      * // Create a new Layer.
@@ -107,7 +109,8 @@
         'align': 'left',
         'offsetX': 0,
         'offsetY': 10,
-        'waiting': '<div class="ch-loading-small"></div>'
+        'waiting': '<div class="ch-loading-small"></div>',
+        'wrapper': false
     });
 
     /**

--- a/src/shared/scripts/Popover.js
+++ b/src/shared/scripts/Popover.js
@@ -29,7 +29,10 @@
      * @param {Boolean} [options.async] Force to sent request asynchronously. Default: true.
      * @param {(String | HTMLElement)} [options.waiting] Temporary content to use while the ajax request is loading. Default: '&lt;div class="ch-loading ch-loading-centered"&gt;&lt;/div&gt;'.
      * @param {(String | HTMLElement)} [options.content] The content to be shown into the Popover container.
+     * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
+     *
      * @returns {popover} Returns a new instance of Popover.
+     *
      * @example
      * // Create a new Popover.
      * var popover = new ch.Popover([el], [options]);
@@ -114,7 +117,8 @@
         'shownby': 'pointertap',
         'hiddenby': 'button',
         'waiting': '<div class="ch-loading ch-loading-centered"></div>',
-        'position': 'absolute'
+        'position': 'absolute',
+        'wrapper': false
     };
 
     /**
@@ -138,6 +142,8 @@
          */
         var that = this,
             container = document.createElement('div');
+
+        this._configureWrapper();
 
         container.innerHTML = [
             '<div',
@@ -388,6 +394,42 @@
     };
 
     /**
+     * Wraps the target element and use the wrapper as the placement for container
+     * @memberof! ch.Popover.prototype
+     * @private
+     * @function
+     */
+    Popover.prototype._configureWrapper = function() {
+        var target = this._el || this._options.reference,
+            wrapper = this._options.wrapper;
+
+        if (wrapper && target && target.nodeType === 1) {
+            // Create the wrapper element and append to it
+            wrapper = document.createElement('span');
+            tiny.addClass(wrapper, 'ch-popover-wrapper');
+
+            if (typeof this._options.wrapper === 'string') {
+                this._options.wrapper.split(' ').forEach(function(className) {
+                    tiny.addClass(wrapper, className);
+                });
+            }
+
+            tiny.parent(target).insertBefore(wrapper, target);
+            wrapper.appendChild(target);
+            if (tiny.css(wrapper, 'position') === 'static') {
+                tiny.css(wrapper, {
+                    display: 'inline-block',
+                    position: 'relative'
+                });
+            }
+
+            this._containerWrapper = wrapper;
+        } else {
+            this._containerWrapper = document.body;
+        }
+    };
+
+    /**
      * Shows the popover container and appends it to the body.
      * @memberof! ch.Popover.prototype
      * @function
@@ -418,8 +460,8 @@
             return this;
         }
 
-        // Append to body
-        document.body.appendChild(this.container);
+        // Append to the configured holder
+        this._containerWrapper.appendChild(this.container);
 
         // Open the collapsible
         this._show();

--- a/src/shared/styles/_popover.scss
+++ b/src/shared/styles/_popover.scss
@@ -10,6 +10,11 @@
     .ch-underlay + & {
         z-index: 1050;
     }
+
+    &-wrapper {
+        display: inline-block;
+        position: relative;
+    }
 }
 
 .ch-shownby-pointertap {

--- a/views/mobile.html
+++ b/views/mobile.html
@@ -914,7 +914,7 @@
 
         var suggestion,
             cancelRequest;
-        var autocomplete = new ch.Autocomplete(qS('.autocomplete'))
+        var autocomplete = new ch.Autocomplete(qS('.autocomplete'), {wrapper: 'ch-autocomplete-wrapper'})
                 .on('type', function (userInput) {
                     // Cancel the jsonp request if any
                     if (cancelRequest) {

--- a/views/ui.html
+++ b/views/ui.html
@@ -1283,7 +1283,7 @@
 
         var suggestion,
             cancelRequest;
-        var autocomplete = new ch.Autocomplete(qS('.autocomplete'))
+        var autocomplete = new ch.Autocomplete(qS('.autocomplete'), {wrapper: 'ch-autocomplete-wrapper'})
                 .on('type', function (userInput) {
                     // Cancel the jsonp request if any
                     if (cancelRequest) {


### PR DESCRIPTION
Add an optional wrapper to the `Popover` component. Since `Autocomplete` uses `Popover` as a content placement now the suggestions list can be placed inside the wrapper and not only attached to the body.

Prevents the next case:
![Demo](http://g.recordit.co/QmMycnWidS.gif)