### PR TITLE
Use proper variable for link color

### DIFF
--- a/src/shared/styles/_typography.scss
+++ b/src/shared/styles/_typography.scss
@@ -55,7 +55,7 @@ h6 {
 a,
 a:active,
 a:link {
-    color: $main-primary-color;
+    color: $links-color;
     text-decoration: none;
 }
 


### PR DESCRIPTION
The variable `$links-color` was already declared on the `shared/styles/_variables.scss` file.

No modifications in the output were made.

---

*This closes #1313.*