### PR TITLE
Mejoramos la regex de validación de emails

### DIFF
--- a/src/shared/scripts/Condition.js
+++ b/src/shared/scripts/Condition.js
@@ -13,7 +13,7 @@
         },
         'email': {
             'fn': function (value) {
-                return (/^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/i).test(value);
+                return (/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/).test(value);
             },
             'message': 'Use a valid e-mail such as name@example.com.'
         },


### PR DESCRIPTION
La regex actual que utiliza Chico valida como positivo emails inválidos y por el contrario, no valida emails inválidos, como son el caso de [emails con acento](https://www.cnet.com/es/noticias/por-fin-gmail-te-dejara-usar-acentos-en-tu-email/)

Propongo una mejora en la regex de validación, utilizando una regex bastante difundida en la web

A continuación podemos ver 
* [una demo de la regex actual de Chico](http://jsfiddle.net/dudesl/ghvj4gy9/36/embedded/result,js/) y comprobar los emails inválidos que valida como positivos
* [una demo de la regex propuesta](http://jsfiddle.net/dudesl/ghvj4gy9/38/embedded/result,js/)

Gracias @axcoro por el aporte!