### PR TITLE
autocomplete with quantity characters

### DIFF
--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -48,6 +48,7 @@
      * @param {Number} [options.offsetY] The offsetY option specifies a distance to displace the target vertically.
      * @param {String} [options.positioned] The positioned option specifies the type of positioning used. You must use: "absolute" or "fixed". Default: "absolute".
      * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
+     * @param {Number} [options.quantityChar] Number of characters required to begin to suggest. Default: 1.
      *
      * @returns {autocomplete}
      * @example
@@ -139,7 +140,8 @@
         '_hiddenby': 'none',
         'keystrokesTime': 150,
         '_itemTemplate': '<li class="{{itemClass}}"{{suggestedData}}>{{term}}<i class="ch-icon-arrow-up" data-js="ch-autocomplete-complete-query"></i></li>',
-        'wrapper': false
+        'wrapper': false,
+        'quantityChar': 1
     };
 
     /**
@@ -250,6 +252,7 @@
         this.trigger.setAttribute('aria-haspopup', 'true');
         this.trigger.setAttribute('aria-owns', this.container.getAttribute('id'));
         this.trigger.setAttribute('autocomplete', 'off');
+        this.trigger.setAttribute('quantityChar', this._options.quantityChar);
 
         tiny.on(this.trigger, 'focus', function turnon() { that._turn('on'); });
         tiny.on(this.trigger, 'blur', function turnoff() {that._turn('off'); });
@@ -268,9 +271,8 @@
         // Used to show when the user cancel the suggestions
         this._originalQuery = this._currentQuery = this._el.value;
 
-        // set the quantity of char for search autocomplete
-        this._quantityChar = document.getElementById(that._el.id).dataset.quantityChar;
-        this._quantityChar = (this._quantityChar !== undefined) ? this._quantityChar : 1;
+        // set the number of characters required to begin to suggest
+        this._quantityChar = document.getElementById(that._el.id).getAttribute('quantitychar');
 
         if (this._configureShortcuts !== undefined) {
             this._configureShortcuts();
@@ -335,9 +337,6 @@
                 }, that._options.keystrokesTime);
             }
         }
-
-
-
 
         function turnOnFallback(e) {
             if (specialKeyCodeMap[e.which || e.keyCode]) {

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -48,7 +48,7 @@
      * @param {Number} [options.offsetY] The offsetY option specifies a distance to displace the target vertically.
      * @param {String} [options.positioned] The positioned option specifies the type of positioning used. You must use: "absolute" or "fixed". Default: "absolute".
      * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
-     * @param {Number} [options.minChar] Number of characters required to begin to suggest. Default: 1.
+     * @param {Number} [options.minChars] Number of characters required to begin to suggest. Default: 1.
      *
      * @returns {autocomplete}
      * @example
@@ -141,7 +141,7 @@
         'keystrokesTime': 150,
         '_itemTemplate': '<li class="{{itemClass}}"{{suggestedData}}>{{term}}<i class="ch-icon-arrow-up" data-js="ch-autocomplete-complete-query"></i></li>',
         'wrapper': false,
-        'minChar': 1
+        'minChars': 1
     };
 
     /**
@@ -252,7 +252,6 @@
         this.trigger.setAttribute('aria-haspopup', 'true');
         this.trigger.setAttribute('aria-owns', this.container.getAttribute('id'));
         this.trigger.setAttribute('autocomplete', 'off');
-        this.trigger.setAttribute('minChar', this._options.minChar);
 
         tiny.on(this.trigger, 'focus', function turnon() { that._turn('on'); });
         tiny.on(this.trigger, 'blur', function turnoff() {that._turn('off'); });
@@ -295,13 +294,12 @@
 
         function turnOn() {
             that._currentQuery = that._el.value.trim();
-            if (that._currentQuery.length >= that._options.minChar) {
-                // when the user writes
-                window.clearTimeout(that._stopTyping);
-
+            // when the user writes
+            window.clearTimeout(that._stopTyping);
+            if (that._currentQuery.length >= that._options.minChars) {
                 that._stopTyping = window.setTimeout(function() {
 
-                    tiny.addClass(that.trigger, that._options.loadingClass);
+                    tiny.addClass(that.trigger, that._options.loadingClass);        
                     /**
                      * Event emitted when the user is typing.
                      * @event ch.Autocomplete#type
@@ -329,11 +327,13 @@
                      *           'crossDomain': true
                      *       });
                      * });
-                     */
+                     */ 
                     that.emit('type', that._currentQuery);
                 }, that._options.keystrokesTime);
+            } else {
+                that._popover.hide();
             }
-        }
+        }   
 
         function turnOnFallback(e) {
             if (specialKeyCodeMap[e.which || e.keyCode]) {

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -48,7 +48,7 @@
      * @param {Number} [options.offsetY] The offsetY option specifies a distance to displace the target vertically.
      * @param {String} [options.positioned] The positioned option specifies the type of positioning used. You must use: "absolute" or "fixed". Default: "absolute".
      * @param {(Boolean | String)} [options.wrapper] Wrap the reference element and place the container into it instead of body. When value is a string it will be applied as additional wrapper class. Default: false.
-     * @param {Number} [options.quantityChar] Number of characters required to begin to suggest. Default: 1.
+     * @param {Number} [options.minChar] Number of characters required to begin to suggest. Default: 1.
      *
      * @returns {autocomplete}
      * @example
@@ -141,7 +141,7 @@
         'keystrokesTime': 150,
         '_itemTemplate': '<li class="{{itemClass}}"{{suggestedData}}>{{term}}<i class="ch-icon-arrow-up" data-js="ch-autocomplete-complete-query"></i></li>',
         'wrapper': false,
-        'quantityChar': 1
+        'minChar': 1
     };
 
     /**
@@ -252,7 +252,7 @@
         this.trigger.setAttribute('aria-haspopup', 'true');
         this.trigger.setAttribute('aria-owns', this.container.getAttribute('id'));
         this.trigger.setAttribute('autocomplete', 'off');
-        this.trigger.setAttribute('quantityChar', this._options.quantityChar);
+        this.trigger.setAttribute('minChar', this._options.minChar);
 
         tiny.on(this.trigger, 'focus', function turnon() { that._turn('on'); });
         tiny.on(this.trigger, 'blur', function turnoff() {that._turn('off'); });
@@ -270,9 +270,6 @@
 
         // Used to show when the user cancel the suggestions
         this._originalQuery = this._currentQuery = this._el.value;
-
-        // set the number of characters required to begin to suggest
-        this._quantityChar = document.getElementById(that._el.id).getAttribute('quantitychar');
 
         if (this._configureShortcuts !== undefined) {
             this._configureShortcuts();
@@ -298,7 +295,7 @@
 
         function turnOn() {
             that._currentQuery = that._el.value.trim();
-            if (that._currentQuery.length >= that._quantityChar) {
+            if (that._currentQuery.length >= that._options.minChar) {
                 // when the user writes
                 window.clearTimeout(that._stopTyping);
 

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -295,46 +295,47 @@
 
 
         function turnOn() {
-     that._currentQuery = that._el.value.trim();
-     if (that._currentQuery.length >= that._quantityChar) {
-         // when the user writes
-         window.clearTimeout(that._stopTyping);
+            that._currentQuery = that._el.value.trim();
+            if (that._currentQuery.length >= that._quantityChar) {
+                // when the user writes
+                window.clearTimeout(that._stopTyping);
 
-         that._stopTyping = window.setTimeout(function() {
+                that._stopTyping = window.setTimeout(function() {
 
-             tiny.addClass(that.trigger, that._options.loadingClass);
-             /**
-              * Event emitted when the user is typing.
-              * @event ch.Autocomplete#type
-              * @example
-              * // Subscribe to "type" event with ajax call
-              * autocomplete.on('type', function (userInput) {
-              *      $.ajax({
-              *          'url': '/countries?q=' + userInput,
-              *          'dataType': 'json',
-              *          'success': function (response) {
-              *              autocomplete.suggest(response);
-              *          }
-              *      });
-              * });
-              * @example
-              * // Subscribe to "type" event with jsonp
-              * autocomplete.on('type', function (userInput) {
-              *       $.ajax({
-              *           'url': '/countries?q='+ userInput +'&callback=parseResults',
-              *           'dataType': 'jsonp',
-              *           'cache': false,
-              *           'global': true,
-              *           'context': window,
-              *           'jsonp': 'parseResults',
-              *           'crossDomain': true
-              *       });
-              * });
-              */
-             that.emit('type', that._currentQuery);
-         }, that._options.keystrokesTime);
-     }
- }
+                    tiny.addClass(that.trigger, that._options.loadingClass);
+                    /**
+                     * Event emitted when the user is typing.
+                     * @event ch.Autocomplete#type
+                     * @example
+                     * // Subscribe to "type" event with ajax call
+                     * autocomplete.on('type', function (userInput) {
+                     *      $.ajax({
+                     *          'url': '/countries?q=' + userInput,
+                     *          'dataType': 'json',
+                     *          'success': function (response) {
+                     *              autocomplete.suggest(response);
+                     *          }
+                     *      });
+                     * });
+                     * @example
+                     * // Subscribe to "type" event with jsonp
+                     * autocomplete.on('type', function (userInput) {
+                     *       $.ajax({
+                     *           'url': '/countries?q='+ userInput +'&callback=parseResults',
+                     *           'dataType': 'jsonp',
+                     *           'cache': false,
+                     *           'global': true,
+                     *           'context': window,
+                     *           'jsonp': 'parseResults',
+                     *           'crossDomain': true
+                     *       });
+                     * });
+                     */
+                    that.emit('type', that._currentQuery);
+                }, that._options.keystrokesTime);
+            }
+        }
+
 
 
 

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -268,6 +268,10 @@
         // Used to show when the user cancel the suggestions
         this._originalQuery = this._currentQuery = this._el.value;
 
+        // set the quantity of char for search autocomplete
+        this._quantityChar = document.getElementById(that._el.id).dataset.quantityChar;
+        this._quantityChar = (this._quantityChar !== undefined) ? this._quantityChar : 1;
+
         if (this._configureShortcuts !== undefined) {
             this._configureShortcuts();
         }
@@ -291,45 +295,48 @@
 
 
         function turnOn() {
-            that._currentQuery = that._el.value.trim();
+     that._currentQuery = that._el.value.trim();
+     if (that._currentQuery.length >= that._quantityChar) {
+         // when the user writes
+         window.clearTimeout(that._stopTyping);
 
-            // when the user writes
-            window.clearTimeout(that._stopTyping);
+         that._stopTyping = window.setTimeout(function() {
 
-            that._stopTyping = window.setTimeout(function () {
+             tiny.addClass(that.trigger, that._options.loadingClass);
+             /**
+              * Event emitted when the user is typing.
+              * @event ch.Autocomplete#type
+              * @example
+              * // Subscribe to "type" event with ajax call
+              * autocomplete.on('type', function (userInput) {
+              *      $.ajax({
+              *          'url': '/countries?q=' + userInput,
+              *          'dataType': 'json',
+              *          'success': function (response) {
+              *              autocomplete.suggest(response);
+              *          }
+              *      });
+              * });
+              * @example
+              * // Subscribe to "type" event with jsonp
+              * autocomplete.on('type', function (userInput) {
+              *       $.ajax({
+              *           'url': '/countries?q='+ userInput +'&callback=parseResults',
+              *           'dataType': 'jsonp',
+              *           'cache': false,
+              *           'global': true,
+              *           'context': window,
+              *           'jsonp': 'parseResults',
+              *           'crossDomain': true
+              *       });
+              * });
+              */
+             that.emit('type', that._currentQuery);
+         }, that._options.keystrokesTime);
+     }
+ }
 
-                tiny.addClass(that.trigger, that._options.loadingClass);
-                /**
-                 * Event emitted when the user is typing.
-                 * @event ch.Autocomplete#type
-                 * @example
-                 * // Subscribe to "type" event with ajax call
-                 * autocomplete.on('type', function (userInput) {
-                 *      $.ajax({
-                 *          'url': '/countries?q=' + userInput,
-                 *          'dataType': 'json',
-                 *          'success': function (response) {
-                 *              autocomplete.suggest(response);
-                 *          }
-                 *      });
-                 * });
-                 * @example
-                 * // Subscribe to "type" event with jsonp
-                 * autocomplete.on('type', function (userInput) {
-                 *       $.ajax({
-                 *           'url': '/countries?q='+ userInput +'&callback=parseResults',
-                 *           'dataType': 'jsonp',
-                 *           'cache': false,
-                 *           'global': true,
-                 *           'context': window,
-                 *           'jsonp': 'parseResults',
-                 *           'crossDomain': true
-                 *       });
-                 * });
-                 */
-                that.emit('type', that._currentQuery);
-            }, that._options.keystrokesTime);
-        }
+
 
         function turnOnFallback(e) {
             if (specialKeyCodeMap[e.which || e.keyCode]) {

--- a/test/autocomplete.spec.js
+++ b/test/autocomplete.spec.js
@@ -205,7 +205,7 @@ describe('ch.Autocomplete', function () {
         });
     });
 
-    describe('It should emits typing event with quantity of characters and', function () {
+    describe('It should emits typing event with quantity of characters and ', function () {
         before(function () {
             autocompleteMinChar._el.focus();
             autocompleteMinChar.emit('type', autocompleteMinChar._el.value);

--- a/test/autocomplete.spec.js
+++ b/test/autocomplete.spec.js
@@ -211,7 +211,7 @@ describe('ch.Autocomplete', function () {
             autocompleteMinChar.emit('type', autocompleteMinChar._el.value);
         });
 
-        it('should trigger the callback function', function () {
+        it('should not show suggestions', function () {
             expect(autocompleteMinChar.isShown()).to.not.be.true;
         });
     });

--- a/test/autocomplete.spec.js
+++ b/test/autocomplete.spec.js
@@ -42,7 +42,7 @@ describe('ch.Autocomplete', function () {
 
         autocomplete = new ch.Autocomplete(document.querySelector('#autocomplete-1'), {'fx': 'none'});
         autocompleteHTML = new ch.Autocomplete(document.querySelector('#autocomplete-2'), {'html': true});
-        autocompleteMinChar = new ch.Autocomplete(document.querySelector('#autocomplete-3'), {'fx': 'none', 'minChar': 4});
+        autocompleteMinChars = new ch.Autocomplete(document.querySelector('#autocomplete-3'), {'fx': 'none', 'minChars': 4});
 
         autocomplete
             .on('type', function () {
@@ -58,7 +58,7 @@ describe('ch.Autocomplete', function () {
             })
             ._el.value = 'ar';
 
-        autocompleteMinChar
+        autocompleteMinChars
             .on('type', function () {
             typingEvent();
             })
@@ -207,12 +207,12 @@ describe('ch.Autocomplete', function () {
 
     describe('It should emits typing event with quantity of characters and ', function () {
         before(function () {
-            autocompleteMinChar._el.focus();
-            autocompleteMinChar.emit('type', autocompleteMinChar._el.value);
+            autocompleteMinChars._el.focus();
+            autocompleteMinChars.emit('type', autocompleteMinChars._el.value);
         });
 
         it('should not show suggestions', function () {
-            expect(autocompleteMinChar.isShown()).to.not.be.true;
+            expect(autocompleteMinChars.isShown()).to.not.be.true;
         });
     });
 

--- a/test/autocomplete.spec.js
+++ b/test/autocomplete.spec.js
@@ -4,6 +4,7 @@ describe('ch.Autocomplete', function () {
     var suggestionsHTML = ['<span class="HTMLAdded">Argentina</span>', '<span class="HTMLAdded">Armenia</span>', '<span class="HTMLAdded">Aruba</span>'];
     var autocomplete;
     var autocompleteHTML;
+    var autocompleteMinChar;
 
     var readyEvent = chai.spy();
     var hideEvent = chai.spy();
@@ -27,11 +28,21 @@ describe('ch.Autocomplete', function () {
                                 '<div class="ch-form-actions">'+
                                     '<input type="submit" class="ch-btn">'+
                                 '</div>'+
+                            '</form>'+
+                            '<form id="form-3" action="./" class="ch-form">'+
+                                '<div class="ch-form-row">'+
+                                    '<label>Test {ID}</label>'+
+                                    '<input id="autocomplete-3" type="text">'+
+                                '</div>'+
+                                '<div class="ch-form-actions">'+
+                                    '<input type="submit" class="ch-btn">'+
+                                '</div>'+
                             '</form>'
         document.body.appendChild(container);
 
         autocomplete = new ch.Autocomplete(document.querySelector('#autocomplete-1'), {'fx': 'none'});
         autocompleteHTML = new ch.Autocomplete(document.querySelector('#autocomplete-2'), {'html': true});
+        autocompleteMinChar = new ch.Autocomplete(document.querySelector('#autocomplete-3'), {'fx': 'none', 'minChar': 4});
 
         autocomplete
             .on('type', function () {
@@ -47,6 +58,12 @@ describe('ch.Autocomplete', function () {
             })
             ._el.value = 'ar';
 
+        autocompleteMinChar
+            .on('type', function () {
+            typingEvent();
+            })
+            .on('ready', readyEvent)
+            ._el.value = 'ar';
     });
 
     after(function () {
@@ -186,7 +203,17 @@ describe('ch.Autocomplete', function () {
         it('should trigger the callback function', function () {
             expect(typingEvent).to.have.been.called();
         });
+    });
 
+    describe('It should emits typing event with quantity of characters and', function () {
+        before(function () {
+            autocompleteMinChar._el.focus();
+            autocompleteMinChar.emit('type', autocompleteMinChar._el.value);
+        });
+
+        it('should trigger the callback function', function () {
+            expect(autocompleteMinChar.isShown()).to.not.be.true;
+        });
     });
 
     describe('Its suggest() method', function () {


### PR DESCRIPTION
#1322 

Se incorporó una nueva feature al textBox autocomplete, con la cual le podemos especificar al momento de instanciar un nuevo autocomplete la cantidad de caracteres (n) que necesitamos para que comience la búsqueda de sugerencias con la propiedad _minChar_. Si dicho parámetro no se incorpora, por default toma 1 caracter, es decir sugiere desde el primero que presionemos.

Ej.: ` var autocomplete = new ch.Autocomplete(qS('.autocomplete'), {wrapper: 'ch-autocomplete-wrapper', minChar: 3}).on...`


![image](https://cloud.githubusercontent.com/assets/18443905/18550277/5d580c84-7b29-11e6-8e19-bd8f6e1b811c.png)
