### PR TITLE
Use beforeshow/beforehide events to handle the Autocomplete shortcuts

### DIFF
--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -462,7 +462,7 @@
         var that = this,
             items = [],
             matchedRegExp = new RegExp('(' + this._currentQuery.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1') + ')', 'ig'),
-            totalItems = 0,
+            totalItems,
             itemDOMCollection,
             itemTemplate = this._options._itemTemplate,
             suggestedItem,

--- a/src/shared/scripts/Autocomplete.js
+++ b/src/shared/scripts/Autocomplete.js
@@ -299,7 +299,7 @@
             if (that._currentQuery.length >= that._options.minChars) {
                 that._stopTyping = window.setTimeout(function() {
 
-                    tiny.addClass(that.trigger, that._options.loadingClass);        
+                    tiny.addClass(that.trigger, that._options.loadingClass);
                     /**
                      * Event emitted when the user is typing.
                      * @event ch.Autocomplete#type
@@ -327,13 +327,13 @@
                      *           'crossDomain': true
                      *       });
                      * });
-                     */ 
+                     */
                     that.emit('type', that._currentQuery);
                 }, that._options.keystrokesTime);
             } else {
-                that._popover.hide();
+                that.suggest([]);
             }
-        }   
+        }
 
         function turnOnFallback(e) {
             if (specialKeyCodeMap[e.which || e.keyCode]) {

--- a/src/ui/scripts/Autocomplete.js
+++ b/src/ui/scripts/Autocomplete.js
@@ -89,10 +89,10 @@
         });
 
         // Activate the shortcuts for this instance
-        this._popover.on('show', function () { ch.shortcuts.on(that.uid); });
+        this._popover.on('beforeshow', function () { ch.shortcuts.on(that.uid); });
 
         // Deactivate the shortcuts for this instance
-        this._popover.on('hide', function () { ch.shortcuts.off(that.uid); });
+        this._popover.on('beforehide', function () { ch.shortcuts.off(that.uid); });
 
         this.on('destroy', function () {
             ch.shortcuts.remove(this.uid);

--- a/views/ui.html
+++ b/views/ui.html
@@ -1281,26 +1281,15 @@
             }
         }
 
-        var suggestion,
-            cancelRequest;
         var autocomplete = new ch.Autocomplete(qS('.autocomplete'), {wrapper: 'ch-autocomplete-wrapper'})
                 .on('type', function (userInput) {
-                    // Cancel the jsonp request if any
-                    if (cancelRequest) {
-                        cancelRequest();
-                    }
-                    // Hide possibly active loading indicator
-                    if (!userInput) {
-                        return autocomplete.suggest([]);
-                    }
-                    cancelRequest = tiny.jsonp('http://suggestgz.mlapps.com/sites/MLA/autosuggest?q=' + userInput + '&v=1', {
+                    tiny.jsonp('http://suggestgz.mlapps.com/sites/MLA/autosuggest?q=' + userInput + '&v=1', {
                         name: 'autocompleteSuggestion',
                         success: parseResults,
                         error: function(err) {
                             autocomplete.suggest([]);
                         }
                     });
-
                 });
 
         autocomplete.container.insertAdjacentHTML('beforeend', extraSuggestions);


### PR DESCRIPTION
Using the `hide` and `show` events may too late to handle the shortcuts when Collapsible has the animations. By using `beforeshow` and `beforehide` we can be sure that shortcuts always will work as expected since this events are triggers always at the same moment independently of animations.