### PR TITLE
Fix for required disabled validation

### DIFF
--- a/src/shared/scripts/Validation.js
+++ b/src/shared/scripts/Validation.js
@@ -263,7 +263,7 @@
                 that.validate();
             }
 
-            if (that.conditions.required === undefined && this.value === '') {
+            if ((that.conditions.required === undefined || that.conditions.required._enabled === false) && this.value === '') {
                 that.clear();
             }
 
@@ -359,7 +359,7 @@
         }
 
         var condition,
-            required = this.conditions.required,
+            required = this.conditions.required && this.conditions.required._enabled,
             value = this._el.value;
 
         // Avoid fields that aren't required when they are empty or de-activated

--- a/test/validation.spec.js
+++ b/test/validation.spec.js
@@ -302,13 +302,19 @@ describe('Validation', function () {
     describe('Its disable() method', function () {
         var instance;
 
-        it('should disable alidation', function () {
+        it('should disable validation', function () {
             instance = validation1.disable();
             expect(validation1.hasError()).to.be.false;
         });
 
         it('should return the same instance than initialized component', function () {
             expect(instance).to.eql(validation1);
+        });
+
+        it('should not have error empty field if required condition is disabled', function () {
+            validation1.disable('required');
+            validation1.trigger.setAttribute('value', '');
+            expect(validation1.hasError()).to.be.false;
         });
     });
 


### PR DESCRIPTION
When disabling “Required” condition on a validation, it validates the other conditions when there is no value in the field.
Also when there is an error from a previous validation, it doesn’t clean the error when deleting the previous value.